### PR TITLE
Update lists.md--removed key points empty list

### DIFF
--- a/episodes/lists.md
+++ b/episodes/lists.md
@@ -389,7 +389,6 @@ resources is ['DVDs', 'abstracts', 'books', 'databases', 'maps', 'periodicals'] 
 - Lists' values can be replaced by assigning to them.
 - Appending items to a list lengthens it.
 - Use `del` to remove items from a list entirely.
-- The empty list contains no values.
 - Lists may contain values of different types.
 - Character strings can be indexed like lists.
 - Character strings are immutable.


### PR DESCRIPTION
Since empty lists are not covered in this section and this concept was moved to the Looping over data sets episode, it should be removed from the key points section of the lists episode. I will also do a pull request to add this to the key points in the looping over data episode.